### PR TITLE
ed25519 signing and key pair generation support

### DIFF
--- a/eddsa.py
+++ b/eddsa.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright 2018 Freie Universitat Berlin
+# Copyright 2018 Inria
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+import cbor
+from pyasn1.type import univ
+from pyasn1.type.namedtype import NamedType, NamedTypes
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+import base64
+
+ASN1_ED25519_TYPE = '1.3.101.112'
+
+COSE_KEY_TYPE = 1
+COSE_KEY_TYPE_OKP = 1
+COSE_KEY_CRV = -1
+COSE_KEY_CRV_ED25519 = 6
+COSE_KEY_ID = 2
+COSE_KEY_PARAM_X = -2
+COSE_KEY_PARAM_D = -4
+
+
+class Identifier(univ.Sequence):
+    componentType = NamedTypes(
+        NamedType('type', univ.ObjectIdentifier())
+    )
+
+
+class PrivKeyContainer(univ.OctetString):
+    pass
+
+
+class EddsaPrivateKey(univ.Sequence):
+    componentType = NamedTypes(
+        NamedType('Version', univ.Integer()),
+        NamedType('Type', Identifier()),
+        NamedType('PrivateKey', univ.OctetString()),
+    )
+
+
+class EddsaPublicKey(univ.Sequence):
+    componentType = NamedTypes(
+        NamedType('Type', Identifier()),
+        NamedType('PublicKey', univ.BitString())
+    )
+
+
+def get_skey(skey_container):
+    container = skey_container['PrivateKey']
+    private_key, _ = der_decoder(container, asn1Spec=PrivKeyContainer)
+    return bytes(private_key)
+
+
+def get_pkey(pkey_container):
+    return bytes(pkey_container['PublicKey'].asOctets())
+
+
+def set_skey(skey_container, skey):
+    container = PrivKeyContainer(value=skey)
+    skey_container['PrivateKey'] = der_encoder(container)
+
+
+"""
+Build an ASN.1 representation from a secret key
+"""
+
+
+def build_asn1privkey(sk):
+    skey = EddsaPrivateKey()
+    skey['Version'] = 0
+    skey_id = Identifier()
+    skey_id['type'] = ASN1_ED25519_TYPE
+    skey['Type'] = skey_id
+    set_skey(skey, sk.to_seed())
+    return skey
+
+
+"""
+Build an ASN.1 representation from a public key
+"""
+
+
+def build_asn1pubkey(pk):
+    pkey = EddsaPublicKey()
+    pkey_id = Identifier()
+    pkey_id['type'] = ASN1_ED25519_TYPE
+    pkey['Type'] = pkey_id
+    pkey['PublicKey'] = univ.BitString.fromOctetString(pk.to_bytes())
+    return pkey
+
+
+"""
+Build a CBOR/COSE representation of a key pair
+"""
+
+
+def build_cbor_privkey(skey, pkey=None, key_id=None):
+    skey_cose = {COSE_KEY_TYPE: COSE_KEY_TYPE_OKP,
+                 COSE_KEY_CRV: COSE_KEY_CRV_ED25519,
+                 COSE_KEY_PARAM_D: skey.to_seed()
+                 }
+    if pkey:
+        skey_cose[COSE_KEY_PARAM_X] = pkey.to_bytes()
+    if key_id:
+        skey_cose[COSE_KEY_ID] = key_id.encode('utf-8')
+    return cbor.dumps(skey_cose)
+
+
+def build_cbor_pubkey(pkey=None, key_id=None):
+    pkey_cose = {COSE_KEY_TYPE: COSE_KEY_TYPE_OKP,
+                 COSE_KEY_CRV: COSE_KEY_CRV_ED25519,
+                 COSE_KEY_PARAM_X: pkey.to_bytes()
+                 }
+    if key_id:
+        pkey_cose[COSE_KEY_ID] = key_id.encode('utf-8')
+    return cbor.dumps(pkey_cose)
+
+
+def parse_privkey(skey):
+    if skey.startswith(b"-----BEGIN PRIVATE KEY-----"):
+        pem_input = skey.decode('ascii')
+        skey = base64.b64decode(''.join(pem_input.splitlines()[1:-1]))
+    keys_input, _ = der_decoder(skey, asn1Spec=EddsaPrivateKey())
+    return get_skey(keys_input)
+
+
+def parse_pubkey(pkey):
+    if pkey.startswith(b"-----BEGIN PUBLIC KEY-----"):
+        pem_input = pkey.decode('ascii')
+        pkey = base64.b64decode(''.join(pem_input.splitlines()[1:-1]))
+    keys_input, _ = der_decoder(pkey, asn1Spec=EddsaPublicKey())
+    return get_pkey(keys_input)

--- a/gen-ed25519.py
+++ b/gen-ed25519.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright 2018 Freie Universitat Berlin
+# Copyright 2018 Inria
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+
+import argparse
+
+import ed25519
+import cbor
+import pyasn1
+import binascii
+import base64
+
+import eddsa
+
+from pyasn1.type import univ
+from pyasn1.type.namedtype import NamedType, NamedTypes
+
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+import base64
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--infile',
+                        type=argparse.FileType('rb'),
+                        help='Input private or combined key file to read from '
+                        'instead of generating new keys')
+    parser.add_argument('-I', '--inform',
+                        choices=['cose', 'pem', 'der'],
+                        default='der',
+                        help='Input key file to read instead of generating'
+                        ' new keys')
+    parser.add_argument('-f', '--outform',
+                        choices=['cose', 'pem', 'der'],
+                        default='der',
+                        help='Specify the output format, pem or der encoded '
+                        'asn1 or COSE signer struct'
+                        )
+    parser.add_argument('-k', '--keyid',
+                        default=None,
+                        help="Key id to add to the COSE signer struct",
+                        )
+    parser.add_argument('skey',
+                        type=argparse.FileType('wb'),
+                        help="File to store the private key in")
+    parser.add_argument('pkey',
+                        nargs='?',
+                        type=argparse.FileType('wb'),
+                        help='File to store the public key in, if none, it is'
+                        'combined in the private key')
+    args = parser.parse_args()
+    public_available = False
+    private_available = False
+
+    if args.infile:
+        input_bytes = args.infile.read()
+        if args.inform == 'cose':
+            try:
+                data = cbor.loads(input_bytes)
+            except:
+                print("Unable to load COSE key from file")
+                exit(1)
+            if eddsa.COSE_KEY_CRV not in data or data[eddsa.COSE_KEY_CRV] != eddsa.COSE_KEY_CRV_ED25519:
+                print("No key curve found or wrong curve type in input")
+                exit(1)
+            try:
+                sk = ed25519.SigningKey(data[eddsa.COSE_KEY_PARAM_D])
+                private_available = True
+            except ValueError:
+                sk = None
+            try:
+                pk = ed25519.VerifyingKey(data[eddsa.COSE_KEY_PARAM_X])
+                public_available = True
+            except ValueError:
+                pk = None
+            try:
+                keyid = data[eddsa.COSE_KEY_ID]
+            except:
+                keyid = None
+        if args.inform == 'der' or args.inform == 'pem':
+            if args.inform == 'pem':
+                input_bytes = base64.b64decode(''.join(input_bytes.splitlines()[1:-1]))
+            sk = parse_privkey(input_bytes)
+            private_available = True
+    else:
+        # Generating new keys
+        sk, pk = ed25519.create_keypair()
+        public_available = True
+        private_available = True
+
+    # Reading input done, converting to output format
+    if not public_available and not private_key:
+        print("missing both public and private key, exiting")
+        exit(1)
+    if not public_available:
+        print("No public key available, only writing private key")
+    if not private_available:
+        print("No private key available, only writing public key")
+
+    if args.outform == 'der' or args.outform == 'pem':
+        if public_available:
+            pkey = eddsa.build_asn1pubkey(pk)
+            pkey_asn1 = eddsa.der_encoder(pkey)
+        if private_available:
+            skey = eddsa.build_asn1privkey(sk)
+            skey_asn1 = der_encoder(skey)
+
+        if args.outform == 'der':
+            if private_available:
+                skey_output = skey_asn1
+            if public_available:
+                pkey_output = pkey_asn1
+        elif args.outform == 'pem':
+            if private_available:
+                skey_output = '-----BEGIN PRIVATE KEY-----\n'.encode('ascii')
+                skey_output += base64.b64encode(skey_asn1)
+                skey_output += '\n-----END PRIVATE KEY-----\n'.encode('ascii')
+            if public_available:
+                pkey_output = '-----BEGIN PUBLIC KEY-----\n'.encode('ascii')
+                pkey_output += base64.b64encode(pkey_asn1)
+                pkey_output += '\n-----END PUBLIC KEY-----\n'.encode('ascii')
+        if private_available:
+            args.skey.write(skey_output)
+        if public_available:
+            args.pkey.write(pkey_output)
+    elif args.outform == 'cose':
+        if args.pkey:
+            skey_output = eddsa.build_cbor_privkey(sk, key_id=args.keyid)
+            pkey_output = eddsa.build_cbor_pubkey(pk, key_id=args.keyid)
+            args.skey.write(skey_output)
+            args.pkey.write(pkey_output)
+        else:
+            if not private_available:
+                print("No private key available to write, aborting")
+                exit(1)
+            else:
+                skey_output = eddsa.build_cbor_privkey(sk, pk, key_id=args.keyid)
+                args.skey.write(skey_output)


### PR DESCRIPTION
This PR adds support for signing with ed25519 keys. As the python cryptography module doesn't support ed25519 yet, I've added an additional python file to parse and build ASN.1/COSE encoded ed25519 keys. If there already is a different python module that supports reading ASN.1 encoded ed25519 keys I'd be happy to convert this to using that module.

The original `sign.py` is adapted to support ed25519 keys. The `ed25519` python module is used to sign the data when using ed25519 keys.

The `gen-ed25519.py` script can generate keys in COSE form and in PEM/DER format. For now only COSE files can be correctly read and converted to PEM/DER, I can supply a follow up to have it also read PEM/DER formatted files and convert them to COSE key.
