### PR TITLE
Fix URI element array order

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -209,7 +209,7 @@ def getPayloadURIs(payloadInfo):
     for uri in docUris:
         if not isinstance(uri,dict):
             raise KeyError('URI entries in the payloadInfo uris field must be maps')
-        uris.append([str(uri['uri']),int(uri['rank'])])
+        uris.append([int(uri['rank']),str(uri['uri'])])
     return uris
 
 def getPayloadDigestAlgorithm(payloadInfo):


### PR DESCRIPTION
As shown in the CDDL code at [page 7](https://tools.ietf.org/html/draft-moran-suit-manifest-01#page-7), the order of an element in the list of URI's is rank first followed by the actual URI. At the moment the generated manifest have this reversed. This PR changes the order to match the RFC draft.