### PR TITLE
Offset support

### DIFF
--- a/examples/example7.json
+++ b/examples/example7.json
@@ -1,0 +1,32 @@
+{
+    "components" : [
+        {
+            "install-id" : ["00"],
+            "install-digest": {
+                "algorithm-id": "sha256",
+                "digest-bytes": "00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210"
+            },
+            "install-size" : 34768,
+            "offset" : 33792,
+            "uri": "http://example.com/file1.bin",
+            "vendor-id" : "fa6b4a53-d5ad-5fdf-be9d-e663e4d41ffe",
+            "class-id" : "1492af14-2569-5e48-bf42-9b2d51f2ab45",
+            "bootable" : true
+        },
+        {
+            "install-id" : ["00"],
+            "install-digest": {
+                "algorithm-id": "sha256",
+                "digest-bytes": "0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff"
+            },
+            "install-size" : 76834,
+            "offset" : 541696,
+            "uri": "http://example.com/file2.bin",
+            "vendor-id" : "fa6b4a53-d5ad-5fdf-be9d-e663e4d41ffe",
+            "class-id" : "1492af14-2569-5e48-bf42-9b2d51f2ab45",
+            "bootable" : true
+        }
+    ],
+    "manifest-version": 1,
+    "manifest-sequence-number": 3
+}

--- a/suit_tool/compile.py
+++ b/suit_tool/compile.py
@@ -83,17 +83,13 @@ def compile_manifest(options, m):
     m = copy.deepcopy(m)
     m['components'] += options.components
     # Compile list of All Component IDs
-    ids = [
-        id for comp_ids in [
+    ids = set([
+        SUITComponentId().from_json(id) for comp_ids in [
             [c[f] for f in [
                 'install-id', 'download-id', 'load-id'
             ] if f in c] for c in m['components']
         ] for id in comp_ids
-    ]
-
-    cids = set([SUITComponentId().from_json(id) for id in ids])
-    suitCommonInfo.component_ids = list(cids)
-
+    ])
     cid_data = {}
     for c in m['components']:
         if not 'install-id' in c:
@@ -106,7 +102,6 @@ def compile_manifest(options, m):
         else:
             cid_data[cid].append(c)
 
-    print(cid_data)
     if not any(c.get('vendor-id', None) for c in m['components']):
         LOG.critical('A vendor-id is required for at least one component')
         raise Exception('No Vendor ID')
@@ -180,7 +175,6 @@ def compile_manifest(options, m):
                 })
             if len(TECseq):
                 TryEachCmd.append(TECseq)
-        print(TryEachCmd)
         if len(TryEachCmd):
             CommonSeq.append(SUITCommand().from_json({
                 'component-id' : cid.to_json(),
@@ -344,9 +338,8 @@ def compile_manifest(options, m):
                 #
                 # )
     #TODO: Text
-
     common = SUITCommon().from_json({
-        'components': ids,
+        'components': [id.to_json() for id in ids],
         'common-sequence': CommonSeq.to_json(),
     })
 

--- a/suit_tool/compile.py
+++ b/suit_tool/compile.py
@@ -34,7 +34,7 @@ from cryptography.hazmat.primitives import hashes
 
 from suit_tool.manifest import SUITComponentId, SUITCommon, SUITSequence, \
                      suitCommonInfo, SUITCommand, SUITManifest, \
-                     SUITWrapper
+                     SUITWrapper, SUITTryEach
 
 LOG = logging.getLogger(__name__)
 
@@ -61,10 +61,14 @@ def hash_file(fname, alg):
 
 
 def mkCommand(cid, name, arg):
+    if hasattr(arg, 'to_json'):
+        jarg = arg.to_json()
+    else:
+        jarg = arg
     return SUITCommand().from_json({
         'component-id' : cid.to_json(),
         'command-id' :  name,
-        'command-arg' : arg
+        'command-arg' : jarg
     })
 
 def check_eq(ids, choices):
@@ -78,6 +82,42 @@ def check_eq(ids, choices):
     neq = { k: ids[k] for k in ids if any([k in c for c in choices]) and check(get(k, choices)) }
     return eq, neq
 
+
+def make_sequence(cid, choices, seq, params, cmds, pcid_key=None, param_drctv='directive-set-parameters'):
+    eqcmds, neqcmds = check_eq(cmds, choices)
+    eqparams, neqparams = check_eq(params, choices)
+    if not pcid_key:
+        pcid = cid
+    else:
+        pcid = SUITComponentId().from_json(choices[0][pcid_key])
+    params = {}
+    for param, pcmd in eqparams.items():
+        k,v = pcmd(pcid, choices[0])
+        params[k] = v
+    if len(params):
+        seq.append(mkCommand(pcid, param_drctv, params))
+    TryEachCmd = SUITTryEach()
+    for c in choices:
+        TECseq = SUITSequence()
+        for item, cmd in neqcmds.items():
+            TECseq.append(cmd(cid, c))
+        params = {}
+        for param, pcmd in neqparams.items():
+            k,v = pcmd(cid, c)
+            params[k] = v
+        print (params)
+        if len(params):
+            TECseq.append(mkCommand(pcid, param_drctv, params))
+        if len(TECseq.items):
+            TryEachCmd.append(TECseq)
+    if len(TryEachCmd.items):
+        print(TryEachCmd)
+        seq.append(mkCommand(cid, 'directive-try-each', TryEachCmd))
+    # Finally, and equal commands
+    for item, cmd in eqcmds.items():
+        print(cmd)
+        seq.append(cmd(cid, choices[0]))
+    return seq
 
 def compile_manifest(options, m):
     m = copy.deepcopy(m)
@@ -102,16 +142,6 @@ def compile_manifest(options, m):
         else:
             cid_data[cid].append(c)
 
-    if not any(c.get('vendor-id', None) for c in m['components']):
-        LOG.critical('A vendor-id is required for at least one component')
-        raise Exception('No Vendor ID')
-
-    if not any(c.get('class-id', None) for c in m['components'] if 'vendor-id' in c):
-        LOG.critical('A class-id is required for at least one component that also has a vendor-id')
-        raise Exception('No Class ID')
-
-    # Construct common sequence
-    CommonSeq = SUITSequence()
     for id, choices in cid_data.items():
         for c in choices:
             if 'file' in c:
@@ -122,203 +152,110 @@ def compile_manifest(options, m):
                 }
                 c['install-size'] = imgsize
 
+    if not any(c.get('vendor-id', None) for c in m['components']):
+        LOG.critical('A vendor-id is required for at least one component')
+        raise Exception('No Vendor ID')
 
+    if not any(c.get('class-id', None) for c in m['components'] if 'vendor-id' in c):
+        LOG.critical('A class-id is required for at least one component that also has a vendor-id')
+        raise Exception('No Class ID')
 
-        # if there is a choice, then we need a try-each for each item that is different.
-        eqcmds, neqcmds = check_eq({
-            'vendor-id': lambda cid, data: {
-                'component-id' : cid.to_json(),
-                'command-id' :  'condition-vendor-identifier',
-                'command-arg' : data['vendor-id']
-            },
-            'class-id': lambda cid, data: {
-                'component-id' : cid.to_json(),
-                'command-id' :  'condition-class-identifier',
-                'command-arg' : data['class-id']
-            },
-            'offset': lambda cid, data: {
-                'component-id' : cid.to_json(),
-                'command-id' :  'condition-component-offset',
-                'command-arg' : data['offset']
-            },
-        }, choices)
-        eqparams, neqparams = check_eq({
-            'install-digest':'image-digest',
-            'install-size':'image-size',
-        }, choices)
+    # Construct common sequence
+    CommonCmds = {
+        'offset': lambda cid, data: mkCommand(cid, 'condition-component-offset', data['offset'])
+    }
+    CommonParams = {
+        'install-digest': lambda cid, data: ('image-digest', data['install-digest']),
+        'install-size': lambda cid, data: ('image-size', data['install-size']),
+    }
+    CommonSeq = SUITSequence()
+    for cid, choices in cid_data.items():
+        if any(['vendor-id' in c for c in choices]):
+            CommonSeq.append(mkCommand(cid, 'condition-vendor-identifier',
+                [c['vendor-id'] for c in choices if 'vendor-id' in c][0]))
+        if any(['vendor-id' in c for c in choices]):
+            CommonSeq.append(mkCommand(cid, 'condition-class-identifier',
+                [c['class-id'] for c in choices if 'class-id' in c][0]))
+        CommonSeq = make_sequence(cid, choices, CommonSeq, CommonParams,
+            CommonCmds, param_drctv='directive-override-parameters')
 
-        # First, set up equal parameters.
-        params = {}
-        for param, mkey in eqparams:
-            params[mkey] = choices[0][param]
-        if len(params):
-            CommonSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' :  "directive-override-parameters",
-                'command-arg' : params
-            }))
+    InstSeq = SUITSequence()
+    FetchSeq = SUITSequence()
+    for cid, choices in cid_data.items():
+        if any([c.get('install-on-download', True) and 'uri' in c for c in choices]):
+            InstParams = {
+                'uri' : lambda cid, data: ('uri', data['uri']),
+            }
+            if any(['compression-info' in c and not c.get('decompress-on-load', False) for c in choices]):
+                InstParams['compression-info'] = lambda cid, data: data.get('compression-info')
+            InstCmds = {
+                'offset': lambda cid, data: mkCommand(
+                    cid, 'condition-component-offset', data['offset'])
+            }
+            InstSeq = make_sequence(cid, choices, InstSeq, InstParams, InstCmds)
+            InstSeq.append(mkCommand(cid, 'directive-fetch', None))
+            InstSeq.append(mkCommand(cid, 'condition-image-match', None))
 
-        # First add try-each components
-        TryEachCmd = []
-        for c in choices:
-            TECseq = []
-            for item, cmd in neqcmds.items():
-                TECseq.append(cmd(cid, c))
-            params = {}
-            for param, mkey in neqparams.items():
-                params[mkey] = c[param]
-            if len(params):
-                TECseq.append({
-                    'component-id' : cid.to_json(),
-                    'command-id' : 'directive-override-parameters',
-                    'command-arg' : params
-                })
-            if len(TECseq):
-                TryEachCmd.append(TECseq)
-        if len(TryEachCmd):
-            CommonSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' : 'directive-try-each',
-                'command-arg' : TryEachCmd
-            }))
-        # Finally, and equal commands
-        for item, cmd in eqcmds.items():
-            CommonSeq.append(SUITCommand().from_json(
-                cmd(cid, choices[0])
-            ))
+        elif any(['uri' in c for c in choices]):
+            FetchParams = {
+                'uri' : lambda cid, data: ('uri', data['uri']),
+                'download-digest' : lambda cid, data : (
+                    'image-digest', data.get('download-digest', data['install-digest']))
+            }
+            if any(['compression-info' in c and not c.get('decompress-on-load', False) for c in choices]):
+                FetchParams['compression-info'] = lambda cid, data: data.get('compression-info')
+
+            FetchCmds = {
+                'offset': lambda cid, data: mkCommand(
+                    cid, 'condition-component-offset', data['offset']),
+                'fetch' : lambda cid, data: mkCommand(
+                    data.get('download-id', cid.to_json()), 'directive-fetch', None),
+                'match' : lambda cid, data: mkCommand(
+                    data.get('download-id', cid.to_json()), 'condition-image-match', None)
+            }
+            FetchSeq = make_sequence(cid, choices, FetchSeq, FetchParams, FetchCmds, 'download-id')
+
+            InstParams = {
+                'download-id' : lambda cid, data : ('source-component', data['download-id'])
+            }
+            InstCmds = {
+            }
+            InstSeq = make_sequence(cid, choices, InstSeq, InstParams, InstCmds)
+            InstSeq.append(mkCommand(cid, 'directive-copy', None))
+            InstSeq.append(mkCommand(cid, 'condition-image-match', None))
 
     # TODO: Dependencies
     # If there are dependencies
         # Construct dependency resolution step
-    InstSeq = SUITSequence()
-    FetchSeq = SUITSequence()
-    # Construct Installation step
-    for c in m['components']:
-        # If install-on-download is true
-        if c.get('install-on-download', True) and 'uri' in c:
-            cid = SUITComponentId().from_json(c['install-id'])
-            params = {'uri' : c['uri']}
-            if 'compression-info' in c and not c.get('decompress-on-load', False):
-                params['compression-info'] = c['compression-info']
-            InstSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' : 'directive-set-parameters',
-                'command-arg' : params
-            }))
-            # Download each component
-            InstSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' : 'directive-fetch',
-                'command-arg' : None
-            }))
-            InstSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' : 'condition-image-match',
-                'command-arg' : None
-            }))
-
-
-        # Else
-        else:
-            if 'uri' in c:
-                dldigest = c.get('download-digest', c['install-digest'])
-                params = {
-                    'uri' : c['uri'],
-                    'image-digest' : dldigest
-                }
-                if 'compression-info' in c and not c.get('decompress-on-load', False):
-                    params['compression-info'] = c['compression-info']
-
-                cid = SUITComponentId().from_json(c['download-id'])
-                # Set URI
-                FetchSeq.append(SUITCommand().from_json({
-                    'component-id' : cid.to_json(),
-                    'command-id' : 'directive-set-parameters',
-                    'command-arg' : params
-                }))
-                # Download component
-                FetchSeq.append(SUITCommand().from_json({
-                    'component-id' : cid.to_json(),
-                    'command-id' : 'directive-fetch',
-                    'command-arg' : None
-                }))
-                # Check digest
-                FetchSeq.append(SUITCommand().from_json({
-                    'component-id' : cid.to_json(),
-                    'command-id' : 'condition-image-match',
-                    'command-arg' : None
-                }))
-                instid = SUITComponentId().from_json(c['install-id'])
-                dlid = SUITComponentId().from_json(c['download-id'])
-
-                # Setup the source component
-                InstSeq.append(SUITCommand().from_json({
-                    'component-id' : instid.to_json(),
-                    'command-id' : 'directive-set-parameters',
-                    'command-arg' : {'source-component' : dlid.to_json()}
-                }))
-
-                # Move each component from download to install
-                InstSeq.append(SUITCommand().from_json({
-                    'component-id' : instid.to_json(),
-                    'command-id' : 'directive-copy',
-                    'command-arg' : None
-                }))
-
-                # Verify each component's install digest
-                InstSeq.append(SUITCommand().from_json({
-                    'component-id' : cid.to_json(),
-                    'command-id' : 'condition-image-match',
-                    'command-arg' : None
-                }))
-
 
     ValidateSeq = SUITSequence()
     RunSeq = SUITSequence()
     LoadSeq = SUITSequence()
     # If any component is marked bootable
-    if any(c.get('bootable', False) for c in m['components']):
-        # Construct system validation
-        for c in m['components']:
-            cid = SUITComponentId().from_json(c['install-id'])
-            # Verify component
-            ValidateSeq.append(SUITCommand().from_json({
-                'component-id' : cid.to_json(),
-                'command-id' : 'condition-image-match',
-                'command-arg' : None
-            }))
+    for cid, choices in cid_data.items():
+        if any([c.get('bootable', False) for c in choices]):
+            # TODO: Dependencies
             # If there are dependencies
                 # Verify dependencies
                 # Process dependencies
-        # Generate image load section
-        for c in m['components']:
-            if c.get('loadable', False):
+            ValidateSeq.append(mkCommand(cid, 'condition-image-match', None))
+
+        if any(['loadable' in c for c in choices]):
+            # Generate image load section
+            LoadParams = {
+                'install-id' : lambda cid, data : ('source-component', c['install-id']),
+                'load-digest' : ('image-digest', c.get('load-digest', c['install-digest'])),
+                'load-size' : ('image-size', c.get('load-size', c['install-size']))
+            }
+            if 'compression-info' in c and c.get('decompress-on-load', False):
+                LoadParams['compression-info'] = lambda cid, data: ('compression-info', c['compression-info'])
+            LoadCmds = {
                 # Move each loadable component
-                loadparams = {
-                    'source-component' : c['install-id'],
-                    'image-digest' : c.get('load-digest', c['install-digest']),
-                    'image-size' : c.get('load-size', c['install-size'])
-                }
-                if 'compression-info' in c and c.get('decompress-on-load', False):
-                    loadparams['compression-info'] = c['compression-info']
-
-                LoadSeq.append(SUITCommand().from_json({
-                    'component-id' : c['load-id'],
-                    'command-id' : 'directive-override-parameters',
-                    'command-arg' : loadparams
-                }))
-                LoadSeq.append(SUITCommand().from_json({
-                    'component-id' : c['load-id'],
-                    'command-id' : 'directive-copy',
-                    'command-arg' : None
-                }))
-                # Verify each modifiable comopnent
-                LoadSeq.append(SUITCommand().from_json({
-                    'component-id' : c['load-id'],
-                    'command-id' : 'condition-image-match',
-                    'command-arg' : None
-                }))
-
+            }
+            load_id = SUITComponentId().from_json(choices[0]['load-id'])
+            LoadSeq = make_sequence(load_id, choices, ValidateSeq, LoadParams, LoadCmds)
+            LoadSeq.append(mkCommand(load_id, 'directive-copy', None))
+            LoadSeq.append(mkCommand(load_id, 'condition-image-match', None))
 
         # Generate image invocation section
         bootable_components = [x for x in m['components'] if x.get('bootable')]

--- a/suit_tool/manifest.py
+++ b/suit_tool/manifest.py
@@ -470,20 +470,20 @@ class SUITSequence(SUITManifestArray):
     field = collections.namedtuple('ArrayElement', 'obj')(obj=SUITCommand)
     def to_suit(self):
         suit_l = []
-        last_cidx = 0 if len(suitCommonInfo.component_ids) == 1 else None
+        suitCommonInfo.current_index = 0 if len(suitCommonInfo.component_ids) == 1 else None
         for i in self.items:
             # print(i.json_key, i.arg)
             if i.json_key == 'directive-set-component-index':
-                last_cidx = i.arg.v
+                suitCommonInfo.current_index = i.arg.v
             else:
                 cidx = suitCommonInfo.component_id_to_index(i.cid)
-                if cidx != last_cidx:
+                if cidx != suitCommonInfo.current_index:
                     # Change component
                     cswitch = SUITCommand().from_json({
                         'command-id' : 'directive-set-component-index',
                         'command-arg' : cidx
                     })
-                    last_cidx = cidx
+                    suitCommonInfo.current_index = cidx
                     suit_l += cswitch.to_suit()
             suit_l += i.to_suit()
         return suit_l
@@ -494,6 +494,11 @@ class SUITSequence(SUITManifestArray):
         return self
 
 SUITTryEach.field = collections.namedtuple('ArrayElement', 'obj')(obj=SUITSequence)
+
+class SUITSequenceComponentReset(SUITSequence):
+    def to_suit(self):
+        suitCommonInfo.current_index = None
+        return super(SUITSequenceComponentReset, self).to_suit()
 
 def SUITMakeSeverableField(c):
     class SUITSeverableField:
@@ -524,7 +529,7 @@ class SUITCommon(SUITManifestDict):
         # 'dependencies' : ('dependencies', 1, SUITBWrapField(SUITDependencies)),
         'components' : ('components', 2, SUITBWrapField(SUITComponents)),
         # 'dependency_components' : ('dependency-components', 3, SUITBWrapField(SUITDependencies)),
-        'common_sequence' : ('common-sequence', 4, SUITBWrapField(SUITSequence)),
+        'common_sequence' : ('common-sequence', 4, SUITBWrapField(SUITSequenceComponentReset)),
     })
 
 
@@ -533,12 +538,12 @@ class SUITManifest(SUITManifestDict):
         'version' : ('manifest-version', 1, SUITPosInt),
         'sequence' : ('manifest-sequence-number', 2, SUITPosInt),
         'common' : ('common', 3, SUITBWrapField(SUITCommon)),
-        'deres' : ('dependency-resolution', 7, SUITMakeSeverableField(SUITSequence)),
-        'fetch' : ('payload-fetch', 8, SUITMakeSeverableField(SUITSequence)),
-        'install' : ('install', 9, SUITMakeSeverableField(SUITSequence)),
-        'validate' : ('validate', 10, SUITBWrapField(SUITSequence)),
-        'load' : ('load', 11, SUITBWrapField(SUITSequence)),
-        'run' : ('run', 12, SUITBWrapField(SUITSequence)),
+        'deres' : ('dependency-resolution', 7, SUITMakeSeverableField(SUITSequenceComponentReset)),
+        'fetch' : ('payload-fetch', 8, SUITMakeSeverableField(SUITSequenceComponentReset)),
+        'install' : ('install', 9, SUITMakeSeverableField(SUITSequenceComponentReset)),
+        'validate' : ('validate', 10, SUITBWrapField(SUITSequenceComponentReset)),
+        'load' : ('load', 11, SUITBWrapField(SUITSequenceComponentReset)),
+        'run' : ('run', 12, SUITBWrapField(SUITSequenceComponentReset)),
     })
 
 class COSE_Algorithms(SUITKeyMap):

--- a/suit_tool/parse.py
+++ b/suit_tool/parse.py
@@ -33,6 +33,6 @@ def main(options):
         print (json.dumps(wrapper.to_json(),indent=2))
     else:
         print ('\n'.join(itertools.chain.from_iterable(
-            map(textwrap.wrap, wrapper.to_debug('').split('\n'))
+            [textwrap.wrap(t, 70) for t in wrapper.to_debug('').split('\n')]
         )))
     return 0

--- a/suit_tool/sign.py
+++ b/suit_tool/sign.py
@@ -69,7 +69,7 @@ def main(options):
     cose_signature.signature = SUITBytes().from_suit(signature_bytes)
 
     auth = SUITBWrapField(COSEList)().from_json([{
-        'cose-sign1' : cose_signature.to_json()
+        'COSE_Sign1_Tagged' : cose_signature.to_json()
     }])
 
     wrapper[SUITWrapper.fields['auth'].suit_key] = auth.to_suit()


### PR DESCRIPTION
Add support for offsets to manifest generator. There are several known issues with multiple component support:

1. The component order is ignored.
2. Digests other than the digest of the installed component may not be inserted.