### PR TITLE
    Fixed signature computation payload.

### DIFF
--- a/suit_tool/sign.py
+++ b/suit_tool/sign.py
@@ -91,15 +91,14 @@ def main(options):
         b'',
         cose_signature.payload.to_suit(),
     ], sort_keys = True)
-    sig_val = cbor.dumps(Sig_structure, sort_keys = True)
-    LOG.debug('Signing: {}'.format(binascii.b2a_hex(sig_val).decode('utf-8')))
+    LOG.debug('Signing: {}'.format(binascii.b2a_hex(Sig_structure).decode('utf-8')))
 
     signature_bytes = {
         'ES256' : get_cose_es_bytes,
         'ES384' : get_cose_es_bytes,
         'ES512' : get_cose_es_bytes,
         'EdDSA' : get_cose_ed25519_bytes,
-    }.get(options.key_type)(private_key, sig_val)
+    }.get(options.key_type)(private_key, Sig_structure)
 
     cose_signature.signature = SUITBytes().from_suit(signature_bytes)
 


### PR DESCRIPTION
    Removed unnecessary step of wrapping the Sig_structure into a
    bytestring before signature computation.
    According to RFC8152 the input for signature creation algorithm should
    be serialized Sig_structure, which is an array representing context,
    protected elements, application data and payload.
    Steps for Sig_structure are described in 4.4 of RFC8152.