### PR TITLE
Fix/incorrect compression info

### DIFF
--- a/examples/example4.json
+++ b/examples/example4.json
@@ -14,7 +14,9 @@
             "loadable" : true,
             "decompress-on-load" : true,
             "load-id" : ["01"],
-            "compression-info" : "gzip"
+            "compression-info" : {
+                "compression-algorithm": "gzip"
+            }
         }
     ],
     "manifest-version": 1,

--- a/suit_tool/manifest.py
+++ b/suit_tool/manifest.py
@@ -365,13 +365,18 @@ class SUITDigest(SUITManifestNamedList):
         'digest' : ('digest-bytes', 1, SUITBytes)
     })
 
-class SUITCompressionInfo(SUITKeyMap):
+class SUITCompressionAlgorithm(SUITKeyMap):
     rkeymap, keymap = SUITKeyMap.mkKeyMaps({
         'gzip' : 1,
         'bzip2' : 2,
         'deflate' : 3,
         'lz4' : 4,
         'lzma' : 7
+    })
+
+class SUITCompressionInfo(SUITManifestDict):
+    fields = SUITManifestDict.mkfields({
+        'compression-algo' : ('compression-algorithm', 1, SUITCompressionAlgorithm)
     })
 
 class SUITParameters(SUITManifestDict):
@@ -382,7 +387,7 @@ class SUITParameters(SUITManifestDict):
         'size' : ('image-size', 14, SUITPosInt),
         'uri' : ('uri', 21, SUITTStr),
         'src' : ('source-component', 22, SUITComponentIndex),
-        'compress' : ('compression-info', 19, SUITCompressionInfo)
+        'compression' : ('compression', 19, SUITBWrapField(SUITCompressionInfo))
     })
     def from_json(self, j):
         # print(j)


### PR DESCRIPTION
According to ietf-04 documentation compression-info parameter should have a form :

  SUIT_Compression_Info = {
      suit-compression-algorithm => SUIT_Compression_Algorithms,
      ? suit-compression-parameters => bstr
  }

but it looks like:

SUIT_Compression_Info = SUIT_Compression_Algorithms

This commit implements this functionality and cleans load-related incompatible with ietf-04 code 