### PR TITLE
Added items sorting

### DIFF
--- a/suit_tool/manifest.py
+++ b/suit_tool/manifest.py
@@ -348,7 +348,7 @@ class SUITComponents(SUITManifestArray):
 
     def from_json(self, j):
         super(SUITComponents, self).from_json(j)
-        suitCommonInfo.component_ids = self.items
+        suitCommonInfo.component_ids = sorted(self.items, key=lambda item: item.items[0].v)
         return self
 
 class SUITDigestAlgo(SUITKeyMap):


### PR DESCRIPTION
self.items are not sorted, and because of that they appear in suitCommonInfo.component_ids in random order:

https://github.com/ARMmbed/suit-manifest-generator/issues/24

This pull request implements sorting mechanism