### PR TITLE
Fix parameter setting for offsets

### DIFF
--- a/suit_tool/compile.py
+++ b/suit_tool/compile.py
@@ -100,12 +100,26 @@ def make_sequence(cid, choices, seq, params, cmds, pcid_key=None, param_drctv='d
     TryEachCmd = SUITTryEach()
     for c in choices:
         TECseq = TryEachCmd.field.obj().from_json([])
-        for item, cmd in neqcmds.items():
-            TECseq.v.append(cmd(cid, c))
         params = {}
         for param, pcmd in neqparams.items():
             k,v = pcmd(cid, c)
             params[k] = v
+        dep_params = {}
+        TECseq_cmds = []
+        for item, cmd in neqcmds.items():
+            ncmd = cmd(cid, c)
+            for dp in ncmd.dep_params:
+                if dp in params:
+                    dep_params[dp] = params[dp]
+                    del params[dp]
+            TECseq_cmds.append(ncmd)
+
+        if len(dep_params):
+            TECseq.v.append(mkCommand(pcid, param_drctv, dep_params))
+        
+        for cmd in TECseq_cmds:
+            TECseq.v.append(cmd)
+
         if len(params):
             TECseq.v.append(mkCommand(pcid, param_drctv, params))
         if hasattr(TECseq, "v") and len(TECseq.v.items):

--- a/suit_tool/manifest.py
+++ b/suit_tool/manifest.py
@@ -427,19 +427,20 @@ class SUITParameters(SUITManifestDict):
         'size' : ('image-size', 14, SUITPosInt),
         'uri' : ('uri', 21, SUITTStr),
         'src' : ('source-component', 22, SUITComponentIndex),
-        'compress' : ('compression-info', 19, SUITCompressionInfo)
+        'compress' : ('compression-info', 19, SUITCompressionInfo),
+        'offset' : ('offset', 5, SUITPosInt)
     })
     def from_json(self, j):
-        # print(j)
         return super(SUITParameters, self).from_json(j)
 
 class SUITTryEach(SUITManifestArray):
     pass
 
-def SUITCommandContainer(jkey, skey, argtype):
+def SUITCommandContainer(jkey, skey, argtype, dp=[]):
     class SUITCmd(SUITCommand):
         json_key = jkey
         suit_key = skey
+        dep_params = dp
         def __init__(self):
             pass
         def to_suit(self):
@@ -483,11 +484,11 @@ class SUITCommand:
         return self.scommands[s[0]]().from_suit(s)
 
 SUITCommand.commands = [
-    SUITCommandContainer('condition-vendor-identifier',    1,  SUITNil),
-    SUITCommandContainer('condition-class-identifier',     2,  SUITNil),
-    SUITCommandContainer('condition-image-match',          3,  SUITNil),
+    SUITCommandContainer('condition-vendor-identifier',    1,  SUITNil, ['vendor-id']),
+    SUITCommandContainer('condition-class-identifier',     2,  SUITNil, ['class-id']),
+    SUITCommandContainer('condition-image-match',          3,  SUITNil, ['digest']),
     SUITCommandContainer('condition-use-before',           4,  SUITNil),
-    SUITCommandContainer('condition-component-offset',     5,  SUITNil),
+    SUITCommandContainer('condition-component-offset',     5,  SUITNil, ['offset']),
     SUITCommandContainer('condition-device-identifier',    24, SUITNil),
     SUITCommandContainer('condition-image-not-match',      25, SUITNil),
     SUITCommandContainer('condition-minimum-battery',      26, SUITNil),


### PR DESCRIPTION
Fix missing setting of component offset for A/B image manifests.

This was a larger issue that appears when a parameter needs to be set in Try-Each prior to executing conditions.