### PR TITLE
Add support for 4k metadata

### DIFF
--- a/parser_examples/suit-app/slot-a-config.json
+++ b/parser_examples/suit-app/slot-a-config.json
@@ -10,8 +10,8 @@
             "target.features_remove"           : ["CRYPTOCELL310"],
             "target.macros_remove"             : ["MBEDTLS_CONFIG_HW_SUPPORT"],
             "target.macros_add"                : ["NRFX_RNG_ENABLED=1", "RNG_ENABLED=1", "NRF_QUEUE_ENABLED=1"],
-            "target.mbed_app_start"            : "0x8400",
-            "target.mbed_app_size"             : "0x7BC00"
+            "target.mbed_app_start"            : "0x9000",
+            "target.mbed_app_size"             : "0x7B000"
         }
     }
 }

--- a/parser_examples/suit-app/slot-b-config.json
+++ b/parser_examples/suit-app/slot-b-config.json
@@ -10,8 +10,8 @@
             "target.features_remove"           : ["CRYPTOCELL310"],
             "target.macros_remove"             : ["MBEDTLS_CONFIG_HW_SUPPORT"],
             "target.macros_add"                : ["NRFX_RNG_ENABLED=1", "RNG_ENABLED=1", "NRF_QUEUE_ENABLED=1"],
-            "target.mbed_app_start"            : "0x84400",
-            "target.mbed_app_size"             : "0x7BC00"
+            "target.mbed_app_start"            : "0x85000",
+            "target.mbed_app_size"             : "0x7B000"
         }
     }
 }

--- a/parser_examples/suitloader/mbed_app.json
+++ b/parser_examples/suitloader/mbed_app.json
@@ -27,15 +27,15 @@
                     "The following memory map describes the partitioning of the NRF52840_DK",
                     "+--------------------------+ <-+ 0x100000",
                     "|                          |",
-                    "|        Slot B App        | Size: 0x7BC00",
+                    "|        Slot B App        | Size: 0x7B000",
                     "|                          |",
-                    "+--------------------------+ <-+ 0x84400",
+                    "+--------------------------+ <-+ 0x85000",
                     "|  Slot B Metadata Header  |",
                     "+--------------------------+ <-+ 0x84000",
                     "|                          |",
-                    "|        Slot A App        | Size: 0x7BC00",
+                    "|        Slot A App        | Size: 0x7B000",
                     "|                          |",
-                    "+--------------------------+ <-+ 0x8400",
+                    "+--------------------------+ <-+ 0x9000",
                     "|  Slot A Metadata Header  |",
                     "+--------------------------+ <-+ 0x8000",
                     "|                          |",
@@ -48,7 +48,7 @@
     "macros": [
         "SUIT_BOOTLOADER_SLOT_A_OFFSET=0x8000",
         "SUIT_BOOTLOADER_SLOT_B_OFFSET=0x84000",
-        "SUIT_BOOTLOADER_HEADER_SIZE=0x400"
+        "SUIT_BOOTLOADER_HEADER_SIZE=0x1000"
     ],
     "target_overrides": {
         "*": {


### PR DESCRIPTION
Default was 1k, which was too small for hss-lms