### PR TITLE
Don't convert SUIT_digest bytes to hex representation

### DIFF
--- a/suit_tool/sign.py
+++ b/suit_tool/sign.py
@@ -96,7 +96,7 @@ def main(options):
         'unprotected' : {},
         'payload' : {
             'algorithm-id' : 'sha256',
-            'digest-bytes' : binascii.b2a_hex(digest.finalize())
+            'digest-bytes' : digest.finalize()
         }
     })
 


### PR DESCRIPTION
This PR fixes a bug in the COSE signature payload. The digest-bytes of the SUIT_digest object should be a bstr with the raw digest as content. In current master the digest-bytes is a hex representation of the digest which results in 1. a twice as long bstr (64 bytes instead of 32 bytes for sha256) and 2. incorrect digest verification on the receiver side.